### PR TITLE
Use webpack externals to avoid bundling node dependencies.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1556,6 +1556,12 @@
         "wildcard": "^2.0.0"
       }
     },
+    "webpack-node-externals": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/webpack-node-externals/-/webpack-node-externals-2.5.2.tgz",
+      "integrity": "sha512-aHdl/y2N7PW2Sx7K+r3AxpJO+aDMcYzMQd60Qxefq3+EwhewSbTBqNumOsCE1JsCUNoyfGj5465N0sSf6hc/5w==",
+      "dev": true
+    },
     "webpack-sources": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-2.2.0.tgz",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   },
   "devDependencies": {
     "webpack": "^5.17.0",
-    "webpack-cli": "^4.4.0"
+    "webpack-cli": "^4.4.0",
+    "webpack-node-externals": "^2.5.2"
   }
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,9 +1,11 @@
 const path = require('path')
+const nodeExternals = require('webpack-node-externals')
 
 module.exports = {
   mode: 'production',
   target: 'node',
   entry: './index.js',
+  externals: [nodeExternals()],
   output: {
     filename: 'index.js',
     path: path.resolve(__dirname, 'build'),


### PR DESCRIPTION
This resolves the problem with file paths changing (and avoids redundant
bundling anyway).
